### PR TITLE
Deprecate image maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 The Kafka REST Proxy provides a RESTful interface to a Kafka cluster. It makes it easy to produce and consume messages, view the state of the cluster, and perform administrative actions without using the native Kafka protocol or clients. It is a part of the [Confluent Platform](https://confluent.io/product/).
 
-This image is currently maintained by the Research Management Systems project at the [University of Calgary](http://www.ucalgary.ca/).
+**NOTE: This image is no longer maintained. See [confluentinc/cp-kafka-rest](https://hub.docker.com/r/confluentinc/cp-kafka-rest/) for Kafka REST images.**


### PR DESCRIPTION
The RMS project will no longer maintain this image. See the images
under confluentinc for replacements.